### PR TITLE
Feature doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,8 @@
 __Feature:__
 
 * Better markdown documentation
+
+__Additions:__
+
+* CHANGELOG.md and CONTRIBUTING.md files
+* Markdown preview script 'doc/preview.py'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ __Additions:__
 
 * CHANGELOG.md and CONTRIBUTING.md files
 * Markdown preview script 'doc/preview.py'
+* Included the main class in the manifest of the generated jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Version in development
+> Based on version -.-.-
+
+__Feature:__
+
+* Better markdown documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ __Additions:__
 * CHANGELOG.md and CONTRIBUTING.md files
 * Markdown preview script 'doc/preview.py'
 * Included the main class in the manifest of the generated jar
+* Written a base Readme.md file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Taking part in the development
+
+## Documentation
+
+The [grip](https://github.com/joeyespo/grip) command line server was used to
+preview locally the Markdown flavored documentation (`.md` files).
+Its installation requires `python3` and `pip` (for python3).
+
+Once installed, use the `python3 doc/preview.py` command from the base directory
+of the project to open a view on the markdown code in the default web browser.
+Type CTRL+C (linux) or Command+. (MacOS) in the terminal to stop the preview.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,10 @@
-# Taking part in the development
+<div align="center">
+  <h1>Taking part in the development</h1>
+</div>
+<div align="center">
+  <a href="README.md">⮌ Parent</a> •
+  <a href="#documentation">Documentation</a>
+</div>
 
 ## Documentation
 
@@ -9,3 +15,6 @@ Its installation requires `python3` and `pip` (for python3).
 Once installed, use the `python3 doc/preview.py` command from the base directory
 of the project to open a view on the markdown code in the default web browser.
 Type CTRL+C (linux) or Command+. (MacOS) in the terminal to stop the preview.
+
+__Warning:__ Grip seems to access the GitHub API. Therefore, the number of pages
+refresh per hour is limited.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ terminal located in the base directory of the project :
 * `mvn package -Dmaven.test.skip=true` to build an all-in-one jar containing the library without running the unit tests.
 
 The main class of the project is `fr.univ_artois.lgi2a.vrpgpu.Main`, and takes
-as an argument the path of the file describing the VRP problem to solve.
+as an argument the path of the [file describing the VRP problem to
+solve](doc/usage.md#about-the-data-files).
 Such files can be found in the `data/` directory.
 
 Assuming that the all-in-one jar is built, then running the program is done using
@@ -88,3 +89,4 @@ This tool is licensed under the [TODO license](LICENSE).
 Registered contributors are:
 
 * Sohaib LAFIFI - _<sohaib.lafifi@univ-artois.fr>_ - designer,developer
+* Yoann KUBERA - _<yoann.kubera@univ-artois.fr>_ - documentation

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@
 </div>
 
 <div align="center">
-[License](LICENSE) •
-[Contributing](CONTRIBUTING.md) •
-[Change log](CHANGELOG.md)
+<a href="LICENSE">License</a> •
+<a href="CONTRIBUTING.md">Contributing</a> •
+<a href="CHANGELOG.md">Change log</a>
 
-[Detailed usage](doc/usage.md) •
-[FAQ](doc/faq.md)
+<a href="doc/usage.md">Detailed usage</a> •
+<a href="doc/faq.md">FAQ</a>
 </div>
 
 ## About

--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
-# vrp-gpu
-VRP on GPU
+<div align="center">
+  <img src="logo.svg" width="500" alt="VRP on GPU" />
+</div>
+
+<!-- START badges-list -->
+<div align="center">
+
+![](https://img.shields.io/static/v1.svg?label=version&message=-.-.-&color=red&style=flat-square)
+![](https://img.shields.io/static/v1.svg?label=release%20date&message=??-??-????&color=red&style=flat-square)
+![](https://img.shields.io/static/v1.svg?label=license&message=TODO&color=green&style=flat-square)
+
+![](https://img.shields.io/static/v1.svg?label=java&message=1.8&color=informational&style=flat-square)
+![](https://img.shields.io/static/v1.svg?label=aparapi&message=1.7.0&color=informational&style=flat-square)
+
+</div>
+<!-- END badges-list -->
+
+<div align="center">
+<h4>VRP solver using the GPU</h4>
+</div>
+
+<div align="center">
+[License](LICENSE) •
+[Contributing](CONTRIBUTING.md) •
+[Change log](CHANGELOG.md)
+
+[Detailed usage](doc/usage.md) •
+[FAQ](doc/faq.md)
+</div>
+
+## About
+
+TODO: General description of the project
+
+## Installation
+
+This project requires a working installation of :
+
+* a Java JDK
+
+* OpenCL (no mandatory, unless you wish to use your GPU)
+
+* [Apache Maven](http://maven.apache.org/)
+
+## Get started
+
+The project is compiled, tested and built using the regular maven commands in a
+terminal located in the base directory of the project :
+
+* `mvn compile` to compile the sources into the build directory ;
+
+* `mvn test` to run the unit tests of the application ;
+
+* `mvn package` to build an all-in-one jar containing the library ;
+
+* `mvn package -Dmaven.test.skip=true` to build an all-in-one jar containing the library without running the unit tests.
+
+The main class of the project is `fr.univ_artois.lgi2a.vrpgpu.Main`, and takes
+as an argument the path of the file describing the VRP problem to solve.
+Such files can be found in the `data/` directory.
+
+Assuming that the all-in-one jar is built, then running the program is done using
+a command like :
+
+```
+java -jar target/vrpgpu-0.1-SNAPSHOT-jar-with-dependencies.jar data/Solomon/50/c101.txt
+```
+
+## Supported versions
+
+The project has been developped and checked in a MacOS environment.
+It relies on the following programs :
+
+| Dependency | Version |
+|------------|---------|
+| Java JDK   | 1.8     |
+| OpenCL     |         |
+
+It also uses libraries, which versions are described [in the network dependencies
+page](https://github.com/sohaibafifi/vrp-gpu/network/dependencies).
+
+__The project provides no warrancy on its behavior in other systems / version.__
+
+## Acknowledgements
+
+This tool is licensed under the [TODO license](LICENSE).
+
+Registered contributors are:
+
+* Sohaib LAFIFI - _<sohaib.lafifi@univ-artois.fr>_ - designer,developer

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -2,7 +2,7 @@
   <h1>F.A.Q.</h1>
 </div>
 <div align="center">
-  <a href="..">⮌ Parent</a> •
+  <a href="../README.md">⮌ Parent</a> •
   <a href="#diagnose-test-failures">Diagnose test failures</a>
 </div>
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,0 +1,12 @@
+<div align="center">
+  <h1>F.A.Q.</h1>
+</div>
+<div align="center">
+  <a href="..">⮌ Parent</a> •
+  <a href="#diagnose-test-failures">Diagnose test failures</a>
+</div>
+
+## Diagnose test failures
+
+If the test fail, first check the cause in `target/surefire-reports/`, and
+expecially the XML files, that are more verbose than the text ones.

--- a/doc/preview.py
+++ b/doc/preview.py
@@ -1,0 +1,3 @@
+from grip import main
+
+main(argv=['-b', '8080'])

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,0 +1,20 @@
+<div align="center">
+  <h1>Detailed usage of the project</h1>
+</div>
+<div align="center">
+  <a href="..">⮌ Parent</a> •
+  <a href="#about-the-data-files">About the data files</a>
+</div>
+
+## About the data files
+
+The instances described by the files from the `data/` use the following naming
+convention :
+
+* The path of files is `data/TYPE/NUM/INST.txt` ;
+
+* `TYPE` models the type of VRP instance (in our examples, Solomon) ;
+
+* `NUM` is the number of clients ;
+
+* `INST` is the name of the instance.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -2,7 +2,7 @@
   <h1>Detailed usage of the project</h1>
 </div>
 <div align="center">
-  <a href="..">⮌ Parent</a> •
+  <a href="../README.md">⮌ Parent</a> •
   <a href="#about-the-data-files">About the data files</a>
 </div>
 

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="500"
+   height="94"
+   viewBox="0 0 132.29166 24.870834"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="logo.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.8336564"
+     inkscape:cx="234.20457"
+     inkscape:cy="101.49854"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1848"
+     inkscape:window-height="1136"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-272.12915)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.01848412px;line-height:1.25;font-family:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.68307841"
+       x="66.592316"
+       y="288.67389"
+       id="text12"><tspan
+         sodipodi:role="line"
+         id="tspan10"
+         x="66.592316"
+         y="288.67389"
+         style="font-size:11.28888893px;text-align:center;text-anchor:middle;stroke-width:0.68307841">VRP on GPU</tspan></text>
+  </g>
+</svg>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <archive>
+                      <manifest>
+                          <mainClass>
+                              fr.univ_artois.lgi2a.vrpgpu.Main
+                          </mainClass>
+                      </manifest>
+                    </archive>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>


### PR DESCRIPTION
Designed the markdown documentation.
Also added the main class in the manifest of the generated jar

## Additions

* CHANGELOG.md and CONTRIBUTING.md files, doc/ dir
* Markdown preview script 'doc/preview.py'
* Included the main class in the manifest of the generated jar
* Written a base Readme.md file

## What's missing

* The contents of the LICENSE file ;
* In the Readme.md file :
    * Replace the _"TODO"_ text by the name of the license in the corresponding badge ;
    * Replace the _"TODO"_ text by the license name in the "Acknowledgements" section ;
    * Replace the _"TODO: General description of the project"_ text by the actual description of the project ;
    * ? Include an acknowledgement related to LGI2A / Artois university in the _"Acknowledgements"_ section ?
* Replace `logo.svg` by a better logo